### PR TITLE
Don't die when lost connection

### DIFF
--- a/db.js
+++ b/db.js
@@ -120,6 +120,10 @@ function onComplete(options, callback) {
         if (req.status === 200 || req.status === 201 || req.status === 202) {
             callback(null, resp);
         }
+        else if (!resp) {
+            // connection lost and req.status is probably 0
+            callback(new Error('Connection lost'));
+        }
         else if (resp.error || resp.reason) {
             var err = new Error(resp.reason || resp.error);
             err.error = resp.error;


### PR DESCRIPTION
Hi.
I've created extra condition for ajax error handler. Now `db` will not throw exception when connection was lost and `responseText` is empty.

Please check it out and upload to kanso repo if everything is cool.
Thank Yury
