### PR TITLE
support slash ('/', '%2F') in database names

### DIFF
--- a/db.js
+++ b/db.js
@@ -167,7 +167,7 @@ exports.guessCurrent = function (loc) {
      * http://wiki.apache.org/couchdb/HTTP_database_API
      */
 
-    var re = /\/([a-z][a-z0-9_\$\(\)\+-\/]*)\/_design\/([^\/]+)\//;
+    var re = /\/(([a-z][a-z0-9_\$\(\)\+-\/]|(?:%2F))*)\/_design\/([^\/]+)\//;
     var match = re.exec(loc.pathname);
 
     if (match) {


### PR DESCRIPTION
guessCurrent should support %2F in database names.  
