### PR TITLE
Use relative-root paths instead of relative paths

### DIFF
--- a/db.js
+++ b/db.js
@@ -394,9 +394,23 @@ function DB(url) {
  * @api public
  */
 
-// TODO: handle full urls, not just db names
 exports.use = function (url) {
-    /* Force leading slash; make absolute path */
+    /* Convert all urls into an absolute path. */
+
+    // From https://gist.github.com/jlong/2428561
+    // We use the DOM to get us info about the url 
+    var parse = document.createElement('a');
+    parse.href = url;
+
+    // First check if it's already absolute:
+    if (parse.href != url) {
+        // We are on the same host
+        // Now ensure we have a relative root-path
+        if (url[0] != '/') parse.href = '/' + url;
+    }
+
+    // Instantiate DB with absolute path
+    url = parse.href;
     return new DB(url);
 };
 


### PR DESCRIPTION
Code in db accessing the database performs relative paths:

    url: this.url + '/_design/' + exports.encode(name) + '/_rewrite' + path

but this assumes the code is being called from the root path, which is not always the case.  I notice the comment that:

     397 // TODO: handle full urls, not just db names
     398 exports.use = function (url) {

but perhaps this is not directly related to this point.  

I believe this can be handled either by demanding that 'url' has a forward slash (probably nicer) or check this in exports.request .  