### PR TITLE
Explicitly require jquery in kanso.  Fixes kanso/db#12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Add `db` to your dependencies section in `kanso.json`.
 
 > run `kanso install` to fetch the package
 
-You also need __jQuery__ to be included on your page, since this module uses
-jQuery.ajax to make requests.
-
-
 ### Events
 
 The db module is an EventEmitter. See the

--- a/db.js
+++ b/db.js
@@ -31,7 +31,8 @@
 
 
 var events = require('events'),
-    _ = require('underscore')._;
+    _ = require('underscore')._,
+    jQuery = require('jquery');
 
 
 /**
@@ -62,17 +63,17 @@ var httpData = function (xhr, type, s) {
         data = xml ? xhr.responseXML : xhr.responseText;
 
     if (xml && data.documentElement.nodeName === "parsererror") {
-        $.error("parsererror");
+        jQuery.error("parsererror");
     }
     if (s && s.dataFilter) {
         data = s.dataFilter(data, type);
     }
     if (typeof data === "string") {
         if (type === "json" || !type && ct.indexOf("json") >= 0) {
-            data = $.parseJSON(data);
+            data = jQuery.parseJSON(data);
         }
         else if (type === "script" || !type && ct.indexOf("javascript") >= 0) {
-            $.globalEval(data);
+            jQuery.globalEval(data);
         }
     }
     return data;
@@ -257,7 +258,7 @@ exports.stringifyQuery = function (query) {
 exports.request = function (options, callback) {
     options.complete = onComplete(options, callback);
     options.dataType = 'json';
-    $.ajax(options);
+    jQuery.ajax(options);
 };
 
 

--- a/kanso.json
+++ b/kanso.json
@@ -7,6 +7,7 @@
     "dependencies": {
         "modules": null,
         "underscore": ">=1.1.5",
-        "events": null
+        "events": null,
+        "jquery": null
     }
 }


### PR DESCRIPTION
The jquery dependency is now explicitly included through require.

This is the "lightest" solution to the hidden dependency on jQuery in that it changes the smallest of code.  It however does require the user to use jQuery through the kanso distribution.
