### PR TITLE
proper handling of http result 401:unauthorized

### DIFF
--- a/db.js
+++ b/db.js
@@ -399,7 +399,7 @@ function DB(url) {
 // TODO: handle full urls, not just db names
 exports.use = function (url) {
     /* Force leading slash; make absolute path */
-    return new DB((url.substr(0, 1) !== '/' ? '/' : '') + url);
+    return new DB(url);
 };
 
 /**


### PR DESCRIPTION
In original version the event "unauthorized" does not get emitted as the sequence of result checking was wrong (it will throw an error when trying to access the data in the response body instead).

By correcting the sequence of checks in onComplete it will now send out the event when figuring out an HTTP return code of 401 as desired (and stated in the documentation of the module).